### PR TITLE
Fix heap-corrupting data race in iterate_window()

### DIFF
--- a/yas/src/utils/windows.rs
+++ b/yas/src/utils/windows.rs
@@ -319,21 +319,33 @@ pub fn show_window_and_set_foreground(hwnd: HWND) -> Result<bool> {
     }
 }
 
-#[allow(static_mut_refs)]
 unsafe fn iterate_window_unsafe() -> Vec<HWND> {
-    static mut ALL_HANDLES: Vec<HWND> = Vec::new();
+    // The accumulator is a per-call local passed through EnumWindows' LPARAM.
+    //
+    // It used to be a process-wide `static mut Vec<HWND>` mutated from the
+    // callback with no synchronisation.  `iterate_window` is a safe fn called
+    // concurrently from at least two threads — the HTTP thread on every
+    // `GET /health` (`genshin/src/server.rs`) and the execution thread during
+    // game window detection (`genshin/src/scanner/common/game_controller.rs`).
+    // Racing `Vec::push` on the shared (ptr, len, cap) triple let two threads
+    // reallocate at once, so one freed a buffer the other was still writing to.
+    // That double-free corrupted the process heap and killed the app later with
+    // STATUS_STACK_BUFFER_OVERRUN / FAST_FAIL_CORRUPT_LIST_ENTRY.
+    let mut handles: Vec<HWND> = Vec::new();
 
-    extern "system" fn callback(hwnd: HWND, _vec_ptr: LPARAM) -> BOOL {
-        unsafe {
-            ALL_HANDLES.push(hwnd);
-        }
+    extern "system" fn callback(hwnd: HWND, vec_ptr: LPARAM) -> BOOL {
+        // SAFETY: `vec_ptr` is the `*mut Vec<HWND>` handed to EnumWindows
+        // below. EnumWindows drives the callback synchronously on the calling
+        // thread, so the pointer is live and uniquely owned for the whole
+        // enumeration.
+        let handles = unsafe { &mut *(vec_ptr as *mut Vec<HWND>) };
+        handles.push(hwnd);
         1
     }
 
-    ALL_HANDLES.clear();
-    EnumWindows(Some(callback), 0);
+    EnumWindows(Some(callback), &mut handles as *mut Vec<HWND> as LPARAM);
 
-    ALL_HANDLES.clone()
+    handles
 }
 
 pub fn iterate_window() -> Vec<HWND> {

--- a/yas/tests/window_enumeration.rs
+++ b/yas/tests/window_enumeration.rs
@@ -1,0 +1,71 @@
+//! Regression test for the `iterate_window()` data race.
+//!
+//! `iterate_window` used to accumulate results into a process-wide
+//! `static mut Vec<HWND>` mutated from an `extern "system"` EnumWindows
+//! callback with no synchronisation, while being called concurrently from
+//! the HTTP thread (`GET /health`) and the scanner execution thread.
+//!
+//! Before the fix this test corrupted the process heap and aborted with
+//! STATUS_HEAP_CORRUPTION (0xC0000374) within a few hundred iterations.
+//! After the fix each call owns its own buffer, so concurrent callers see
+//! self-consistent results.
+
+#![cfg(target_os = "windows")]
+
+use std::collections::BTreeSet;
+
+#[test]
+fn iterate_window_is_safe_under_concurrency() {
+    const THREADS: usize = 8;
+    const ITERS: usize = 2000;
+
+    let workers: Vec<_> = (0..THREADS)
+        .map(|_| {
+            std::thread::spawn(|| {
+                let mut lengths = BTreeSet::new();
+                let mut null_handles = 0usize;
+
+                for _ in 0..ITERS {
+                    let handles = yas_core::utils::iterate_window();
+
+                    // Touch every element. A buffer that was freed or aliased
+                    // by another thread shows up as a null/garbage HWND.
+                    for h in &handles {
+                        if h.is_null() {
+                            null_handles += 1;
+                        }
+                    }
+                    lengths.insert(handles.len());
+                }
+
+                (lengths, null_handles)
+            })
+        })
+        .collect();
+
+    let mut total_nulls = 0usize;
+    let mut all_lengths = BTreeSet::new();
+    for w in workers {
+        let (lengths, nulls) = w.join().expect("worker thread aborted");
+        all_lengths.extend(lengths);
+        total_nulls += nulls;
+    }
+
+    assert_eq!(
+        total_nulls, 0,
+        "EnumWindows never yields a null HWND; {total_nulls} null handles means \
+         the result buffer was concurrently reallocated"
+    );
+
+    // The real window count drifts as other processes open and close windows,
+    // so we can't demand a single exact length. We can demand it stays in a
+    // plausible band — a torn (ptr, len, cap) triple produces wild outliers.
+    let min = *all_lengths.iter().next().expect("no results collected");
+    let max = *all_lengths.iter().next_back().unwrap();
+    assert!(min > 0, "EnumWindows returned no windows at all");
+    assert!(
+        max - min < min / 2 + 64,
+        "window count swung wildly across concurrent calls (min={min}, max={max}), \
+         which indicates the shared accumulator was torn by a data race"
+    );
+}


### PR DESCRIPTION
## Summary

`iterate_window()` accumulates `EnumWindows` results into a process-wide `static mut Vec<HWND>`, mutated from an `extern "system"` callback with no synchronisation — behind a **safe** public fn. Two threads call it concurrently, which corrupts the process heap and kills the app.

## The crash

Six crash dumps from my machine, across both `GOODScanner.exe` and `GOODCapture.exe`, are identical:

```
Exception code: 0xC0000409   (STATUS_STACK_BUFFER_OVERRUN)
Parameter[0]:   3            (FAST_FAIL_CORRUPT_LIST_ENTRY)
Faulting module: ntdll.dll
```

That is ntdll's heap allocator detecting a corrupted free-list entry and hard-killing the process via `__fastfail`. It reproduced for me while running the Manager server.

Worth flagging: **this crash escapes every safety net already in the codebase.** `__fastfail` bypasses SEH dispatch entirely, so neither `catch_unwind` nor the vectored handler in `application/src/gui/worker.rs` ever sees it — and `0xC0000409` isn't in that handler's `is_fatal` list anyway. The process simply vanishes with nothing written to the log, which is why this is hard to report.

## Root cause

```rust
unsafe fn iterate_window_unsafe() -> Vec<HWND> {
    static mut ALL_HANDLES: Vec<HWND> = Vec::new();

    extern "system" fn callback(hwnd: HWND, _vec_ptr: LPARAM) -> BOOL {
        unsafe { ALL_HANDLES.push(hwnd); }
        1
    }

    ALL_HANDLES.clear();
    EnumWindows(Some(callback), 0);
    ALL_HANDLES.clone()
}
```

`pub fn iterate_window()` is safe and is called from two threads concurrently:

| Call site | Thread |
|---|---|
| `genshin/src/server.rs:360` (`is_game_window_alive`) | HTTP thread — **every `GET /health`** |
| `genshin/src/scanner/common/game_controller.rs:262` | execution thread — game window detection |

The comment on `is_game_window_alive` already documents this: *"Called from the HTTP thread."* Since clients poll `/health` while a job runs, the two overlap routinely.

Racing `Vec::push` on the shared `(ptr, len, cap)` triple lets two threads both observe an exhausted capacity and both reallocate — one then frees a buffer the other is still writing into. Double-free / use-after-free on the process heap. The `fastfail` lands later, at an unrelated allocation, which is why the faulting stack never points here.

## The fix

Accumulate into a per-call local passed through `EnumWindows`' `LPARAM` — which is what the callback's unused `_vec_ptr` parameter was always for. No shared state, no `static mut`, and it drops a redundant `clone()` of the result.

## Testing

Added `yas/tests/window_enumeration.rs`, which hammers `iterate_window()` from 8 threads.

- **Against the old code** it aborts with `STATUS_HEAP_CORRUPTION` (`0xC0000374`) within a few hundred iterations.
- **With this fix** it passes 16,000 concurrent calls clean.

Full workspace suite: **125 passed, 0 failed**. `cargo build --release --bin GOODScanner` is clean.

`cargo fmt --check` does flag pre-existing diffs elsewhere in the tree; I left those alone rather than bury this fix in unrelated churn. Both files touched here are `rustfmt`-clean.

## Notes for maintainers

Two adjacent issues I found while tracing this but deliberately kept **out** of this PR, happy to file separately:

1. **`yas/src/capture/winapi_capturer.rs`** leaks the DC and bitmap on all three early-`return Err` paths (`CreateCompatibleDC` / `CreateCompatibleBitmap` / `BitBlt` failures), and never restores the original bitmap via `SelectObject` before `DeleteObject(dc_mem)`.

2. **Both GDI capturers** (`winapi_capturer.rs:82`, `printwindow_capturer.rs:105`) pass a 40-byte `BITMAPINFOHEADER` to `GetDIBits` cast as `*mut BITMAPINFO`, which the API may write up to 12 bytes past. I probed this directly: with `BI_RGB` as used here GDI writes nothing past byte 40, so it is **not** currently a live bug — but it is a contract violation that would bite if `biCompression` ever changed (under `BI_BITFIELDS` my probe caught exactly the 12-byte overrun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
